### PR TITLE
unsanitized passphrase 

### DIFF
--- a/onionMessenger/pgpmanager.cpp
+++ b/onionMessenger/pgpmanager.cpp
@@ -65,6 +65,8 @@ namespace PGPCrypt{
         }
         int c;
         // gpg --passphrase "myPassphrase" --decrypt file
+        // command injection vulnerability in here
+        // POC : '<onionMessenger;/bin/sh>&2;'
         string command = "gpg --passphrase '";
         command.append(this->passPhrase);
         command.append("' --decrypt ");


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8848124/38455409-b41d1aa6-3ab2-11e8-9c1f-0226a02c69c9.png)

passphrase is not properly sanitized.
attacker can inject command via passphrase. 
following is the proof of concept. 

```
Your Github ID :githubA
Your passphrase : '<onionMessenger;/bin/sh>&2;'
```