### PR TITLE
command injection in PGPManager::Enc

### DIFF
--- a/onionMessenger/pgpmanager.cpp
+++ b/onionMessenger/pgpmanager.cpp
@@ -25,6 +25,8 @@ namespace PGPCrypt{
         string change_plain = "";
         int c;
 
+        // ReplaceAll has a problem with escaping " charector.
+        // therefore command injection is still available.
         change_plain = ReplaceAll(input_plain, std::string("\""), std::string("\\\""));
         string command = "echo \"";
         command.append(change_plain);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8848124/38460449-f32287c6-3af4-11e8-82f5-c8b393389b49.png)

There is a problem in PGPManager::Enc.
Since " character of input value is not properly escaped, 
command injection is still available.


POC : `";/bin/bash 1>&2;"`