### PR TITLE
improper function ReplaceAll causes denial of service

### DIFF
--- a/onionMessenger/pgpmanager.cpp
+++ b/onionMessenger/pgpmanager.cpp
@@ -25,6 +25,8 @@ namespace PGPCrypt{
         string change_plain = "";
         int c;
 
+        // There's problem with escaping " charector.
+        // command injection is still available.
         change_plain = ReplaceAll(input_plain, std::string("\""), std::string("\\\""));
         string command = "echo \"";
         command.append(change_plain);

--- a/onionMessenger/pgpmanager.cpp
+++ b/onionMessenger/pgpmanager.cpp
@@ -43,6 +43,7 @@ namespace PGPCrypt{
         return enc;
     }
 
+    // input_cipher is not properly sanitized.
     string PGPManager::Dec(string input_cipher){
         FILE *pipe;
         string dec = "";
@@ -65,6 +66,8 @@ namespace PGPCrypt{
         }
         int c;
         // gpg --passphrase "myPassphrase" --decrypt file
+        // command injection vulnerability in here
+        // POC : '<onionMessenger;/bin/sh>&2;'
         string command = "gpg --passphrase '";
         command.append(this->passPhrase);
         command.append("' --decrypt ");

--- a/onionMessenger/pgpmanager.cpp
+++ b/onionMessenger/pgpmanager.cpp
@@ -25,8 +25,9 @@ namespace PGPCrypt{
         string change_plain = "";
         int c;
 
-        // There's problem with escaping " charector.
-        // command injection is still available.
+        // by unproper function ReplaceAll,
+        // data format(json format) is broken.
+        // this triggers unexpected termination of the other party
         change_plain = ReplaceAll(input_plain, std::string("\""), std::string("\\\""));
         string command = "echo \"";
         command.append(change_plain);


### PR DESCRIPTION
Before 
![20180408_063828](https://user-images.githubusercontent.com/8848124/38460623-792bd1e4-3af8-11e8-8ad4-4619617d4d4f.png)

After
![20180408_063844](https://user-images.githubusercontent.com/8848124/38460624-7d3f841a-3af8-11e8-9d38-a27b949563f9.png)


By using improper function ReplaceAll,
data format(json format) is broken.
this triggers unexpected termination of the other party (while parsing broken json data)


POC : `"`